### PR TITLE
Added product search with name and dietary filtering

### DIFF
--- a/server/src/main/java/nz/ac/auckland/grocerfy/controller/ProductController.java
+++ b/server/src/main/java/nz/ac/auckland/grocerfy/controller/ProductController.java
@@ -1,0 +1,37 @@
+package nz.ac.auckland.grocerfy.controller;
+
+import java.util.List;
+
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import nz.ac.auckland.grocerfy.dto.ProductSearchResponse;
+import nz.ac.auckland.grocerfy.service.ProductSearchService;
+
+/**
+ * Controller for handling product search requests.
+ * Both parameters are optional. The name match is a case-insensitive substring
+ * search, and when several dietary tags are supplied only products carrying all
+ * of them are returned.
+ */
+@RestController
+@RequestMapping("/api/product")
+@CrossOrigin(origins = "http://localhost:5173")
+public class ProductController {
+
+	private final ProductSearchService productSearchService;
+
+	public ProductController(ProductSearchService productSearchService) {
+		this.productSearchService = productSearchService;
+	}
+
+	@GetMapping
+	public List<ProductSearchResponse> search(
+			@RequestParam(required = false) String query,
+			@RequestParam(required = false) List<String> dietary) {
+		return productSearchService.search(query, dietary);
+	}
+}

--- a/server/src/main/java/nz/ac/auckland/grocerfy/dto/ProductSearchResponse.java
+++ b/server/src/main/java/nz/ac/auckland/grocerfy/dto/ProductSearchResponse.java
@@ -1,0 +1,18 @@
+package nz.ac.auckland.grocerfy.dto;
+
+/**
+ * The dietary flags are included so the client can render tag badges and show
+ * why a product matched the selected filters.
+ */
+public record ProductSearchResponse(
+		Long productId,
+		String productName,
+		String displayName,
+		String brand,
+		String category,
+		String packageSize,
+		boolean lactoseFree,
+		boolean glutenFree,
+		boolean vegetarian,
+		boolean vegan) {
+}

--- a/server/src/main/java/nz/ac/auckland/grocerfy/repository/ProductRepository.java
+++ b/server/src/main/java/nz/ac/auckland/grocerfy/repository/ProductRepository.java
@@ -1,0 +1,41 @@
+package nz.ac.auckland.grocerfy.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import java.util.List;
+import nz.ac.auckland.grocerfy.model.Product;
+
+public interface ProductRepository extends JpaRepository<Product, Long> {
+ 
+	/**
+	 * Search products by name substring and dietary tags
+	 *
+	 * The name pattern is matched case-insensitively, callers pass an
+	 * already-lowercased LIKE pattern (for example "%milk%", or "%" to match
+	 * everything). 
+	 * Each dietary flag is an independent AND clause, when a flag is false the
+	 * clause is satisfied by every row, and when true only products carrying that
+	 * tag survive. 
+	 * @param pattern     lowercased SQL LIKE pattern for the product name
+	 * @param lactoseFree restrict results to lactose free products
+	 * @param glutenFree  restrict results to gluten free products
+	 * @param vegetarian  restrict results to vegetarian products
+	 * @param vegan       restrict results to vegan products
+	 * @return matching products ordered by name
+	 */
+	@Query("""
+			SELECT p FROM Product p
+			WHERE LOWER(p.productName) LIKE :pattern
+			  AND (:lactoseFree = FALSE OR p.lactoseFree = TRUE)
+			  AND (:glutenFree  = FALSE OR p.glutenFree  = TRUE)
+			  AND (:vegetarian  = FALSE OR p.vegetarian  = TRUE)
+			  AND (:vegan       = FALSE OR p.vegan       = TRUE)
+			ORDER BY p.productName
+			""")
+	List<Product> search(@Param("pattern") String pattern,
+			@Param("lactoseFree") boolean lactoseFree,
+			@Param("glutenFree") boolean glutenFree,
+			@Param("vegetarian") boolean vegetarian,
+			@Param("vegan") boolean vegan);
+}

--- a/server/src/main/java/nz/ac/auckland/grocerfy/service/ProductSearchService.java
+++ b/server/src/main/java/nz/ac/auckland/grocerfy/service/ProductSearchService.java
@@ -1,0 +1,100 @@
+package nz.ac.auckland.grocerfy.service;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import nz.ac.auckland.grocerfy.dto.ProductSearchResponse;
+import nz.ac.auckland.grocerfy.model.Product;
+import nz.ac.auckland.grocerfy.repository.ProductRepository;
+
+/**
+ * Service backing the product search endpoint. It is responsible for querying the repository and mapping the results onto the response DTO. 
+ * It also validates and normalises the caller's dietary tag names.
+ */
+@Service
+public class ProductSearchService {
+
+	private static final String LACTOSE_FREE = "lactosefree";
+	private static final String GLUTEN_FREE = "glutenfree";
+	private static final String VEGETARIAN = "vegetarian";
+	private static final String VEGAN = "vegan";
+
+	private static final Set<String> SUPPORTED_TAGS = Set.of(LACTOSE_FREE, GLUTEN_FREE, VEGETARIAN, VEGAN);
+
+	private final ProductRepository productRepository;
+
+	public ProductSearchService(ProductRepository productRepository) {
+		this.productRepository = productRepository;
+	}
+
+	/**
+	 * Find products whose name contains the given query and which carry every one
+	 * of the requested dietary tags.
+	 * @param query   substring to match against the product name, case-insensitive
+	 * @param dietary dietary tag names, matched products must carry all of them
+	 * @return matching products ordered by name
+	 */
+	@Transactional(readOnly = true)
+	public List<ProductSearchResponse> search(String query, List<String> dietary) {
+		Set<String> tags = normaliseTags(dietary);
+
+		String pattern = (query == null || query.isBlank())
+				? "%"
+				: "%" + query.trim().toLowerCase() + "%";
+
+		return productRepository.search(
+				pattern,
+				tags.contains(LACTOSE_FREE),
+				tags.contains(GLUTEN_FREE),
+				tags.contains(VEGETARIAN),
+				tags.contains(VEGAN))
+				.stream()
+				.map(this::toResponse)
+				.toList();
+	}
+
+	/**
+	 * Normalise supplied tag names by lowercasing and stripping separators, so
+	 * "gluten-free", "gluten_free" and "glutenFree" are all accepted.
+	 */
+	private Set<String> normaliseTags(List<String> dietary) {
+		Set<String> tags = new HashSet<>();
+		if (dietary == null) {
+			return tags;
+		}
+
+		for (String raw : dietary) {
+			if (raw == null || raw.isBlank()) {
+				continue;
+			}
+			String tag = raw.trim().toLowerCase().replaceAll("[^a-z]", "");
+			if (!SUPPORTED_TAGS.contains(tag)) {
+				throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+						"Unknown dietary tag: '" + raw.trim() + "'. Supported tags are: "
+								+ "lactose_free, gluten_free, vegetarian, vegan.");
+			}
+			tags.add(tag);
+		}
+		return tags;
+	}
+
+	private ProductSearchResponse toResponse(Product product) {
+		return new ProductSearchResponse(
+				product.getProductId(),
+				product.getName(),
+				product.getDisplayName(),
+				product.getBrand(),
+				product.getCategory(),
+				product.getPackageSize(),
+				product.isLactoseFree(),
+				product.isGlutenFree(),
+				product.isVegetarian(),
+				product.isVegan());
+	}
+}

--- a/server/src/test/java/nz/ac/auckland/grocerfy/ProductRepositoryTest.java
+++ b/server/src/test/java/nz/ac/auckland/grocerfy/ProductRepositoryTest.java
@@ -1,0 +1,95 @@
+package nz.ac.auckland.grocerfy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.test.context.TestPropertySource;
+
+import nz.ac.auckland.grocerfy.model.Product;
+import nz.ac.auckland.grocerfy.repository.ProductRepository;
+
+/**
+ * Tests the search query in isolation using fixtures created by the test itself.
+ */
+@DataJpaTest
+@TestPropertySource(properties = "spring.sql.init.mode=never")
+class ProductRepositoryTest {
+
+	private static final String ANY_NAME = "%";
+
+	@Autowired
+	private ProductRepository productRepository;
+
+	@BeforeEach
+	void seedFixtures() {
+		productRepository.deleteAll();
+		// name, brand, lactoseFree, glutenFree, vegetarian, vegan
+		productRepository.save(product("Trim Milk", "Anchor", false, true, true, false));
+		productRepository.save(product("Oat Milk", "Otis", true, true, true, true));
+		productRepository.save(product("White Bread", "Tip Top", true, false, true, true));
+		productRepository.save(product("Chicken Breast", "Tegel", true, true, false, false));
+	}
+
+	@Test
+	void matchesNameCaseInsensitively() {
+		List<Product> results = productRepository.search("%milk%", false, false, false, false);
+
+		assertThat(results).extracting(Product::getName)
+				.containsExactly("Oat Milk", "Trim Milk");
+	}
+
+	@Test
+	void matchesPartialSubstringAnywhereInName() {
+		List<Product> results = productRepository.search("%rea%", false, false, false, false);
+
+		assertThat(results).extracting(Product::getName)
+				.containsExactly("Chicken Breast", "White Bread");
+	}
+
+	@Test
+	void returnsEverythingWhenNoFiltersApplied() {
+		List<Product> results = productRepository.search(ANY_NAME, false, false, false, false);
+
+		assertThat(results).hasSize(4);
+	}
+
+	@Test
+	void filtersBySingleDietaryTag() {
+		List<Product> results = productRepository.search(ANY_NAME, false, false, false, true);
+
+		assertThat(results).extracting(Product::getName)
+				.containsExactlyInAnyOrder("Oat Milk", "White Bread");
+	}
+
+	@Test
+	void requiresAllSelectedTagsNotAnyOfThem() {
+		// White Bread is vegan but not gluten-free, so it must be excluded.
+		List<Product> results = productRepository.search(ANY_NAME, false, true, false, true);
+
+		assertThat(results).extracting(Product::getName).containsExactly("Oat Milk");
+	}
+
+	@Test
+	void combinesNameAndDietaryFilters() {
+		List<Product> results = productRepository.search("%milk%", false, false, false, true);
+
+		assertThat(results).extracting(Product::getName).containsExactly("Oat Milk");
+	}
+
+	@Test
+	void returnsEmptyListWhenNothingMatches() {
+		List<Product> results = productRepository.search("%nosuchproduct%", false, false, false, false);
+
+		assertThat(results).isEmpty();
+	}
+
+	private Product product(String name, String brand, boolean lactoseFree, boolean glutenFree,
+			boolean vegetarian, boolean vegan) {
+		return new Product(null, name, brand, "Test", "1kg", lactoseFree, glutenFree, vegetarian, vegan);
+	}
+}

--- a/server/src/test/java/nz/ac/auckland/grocerfy/ProductSearchControllerTest.java
+++ b/server/src/test/java/nz/ac/auckland/grocerfy/ProductSearchControllerTest.java
@@ -1,0 +1,94 @@
+package nz.ac.auckland.grocerfy;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * End to end tests for the product search endpoint
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+class ProductSearchControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Test
+	void returnsWholeCatalogueWhenNoParametersGiven() throws Exception {
+		mockMvc.perform(get("/api/product"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$[?(@.productName == 'Apple')]").exists())
+				.andExpect(jsonPath("$[?(@.productName == 'Chicken Breast')]").exists());
+	}
+
+	@Test
+	void matchesProductNameCaseInsensitively() throws Exception {
+		mockMvc.perform(get("/api/product").param("query", "PIZZA"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.length()").value(2))
+				.andExpect(jsonPath("$[0].productName").value("Pizza"))
+				.andExpect(jsonPath("$[1].productName").value("Vegetarian Pizza"));
+	}
+
+	@Test
+	void matchesPartialSubstringAnywhereInName() throws Exception {
+		mockMvc.perform(get("/api/product").param("query", "rea"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$[?(@.productName == 'Chicken Breast')]").exists())
+				.andExpect(jsonPath("$[?(@.productName == 'White Bread')]").exists());
+	}
+
+	@Test
+	void appliesEverySelectedDietaryTag() throws Exception {
+		// White Bread is vegan but not gluten-free, so a strict AND must exclude it.
+		mockMvc.perform(get("/api/product").param("dietary", "gluten_free").param("dietary", "vegan"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$[?(@.glutenFree == false)]").isEmpty())
+				.andExpect(jsonPath("$[?(@.vegan == false)]").isEmpty())
+				.andExpect(jsonPath("$[?(@.productName == 'White Bread')]").isEmpty())
+				.andExpect(jsonPath("$[?(@.productName == 'Apple')]").exists());
+	}
+
+	@Test
+	void acceptsCommaSeparatedTagList() throws Exception {
+		mockMvc.perform(get("/api/product").param("dietary", "gluten_free,vegan"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$[?(@.glutenFree == false)]").isEmpty())
+				.andExpect(jsonPath("$[?(@.vegan == false)]").isEmpty());
+	}
+
+	@Test
+	void acceptsAlternativeTagSpellings() throws Exception {
+		mockMvc.perform(get("/api/product").param("dietary", "gluten-free"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$[?(@.glutenFree == false)]").isEmpty());
+	}
+
+	@Test
+	void combinesNameAndDietaryFilters() throws Exception {
+		mockMvc.perform(get("/api/product").param("query", "pizza").param("dietary", "vegetarian"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.length()").value(1))
+				.andExpect(jsonPath("$[0].productName").value("Vegetarian Pizza"));
+	}
+
+	@Test
+	void returnsEmptyArrayWhenNothingMatches() throws Exception {
+		mockMvc.perform(get("/api/product").param("query", "notarealproduct"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.length()").value(0));
+	}
+
+	@Test
+	void rejectsUnknownDietaryTag() throws Exception {
+		mockMvc.perform(get("/api/product").param("dietary", "carnivore"))
+				.andExpect(status().isBadRequest());
+	}
+}


### PR DESCRIPTION
Implements `query` and `dietary` parameters. Name matching is a case insensitive substring search, when multiple dietary tags are supplied they are ANDed, so only products carrying every selected tag are returned. Adds a `search()` query to ProductRepository, a service layer that normalises tag names, and a DTO carrying the dietary flags.
Contributes towards #14 