### PR TITLE
Edited build.yml name so that sonar.yml runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: SonarQube
+name: Build
 on:
   push:
     branches:


### PR DESCRIPTION
Sonar.yml is not run after build due to issue with naming, fixed in this pull request and works toward #21 