### PR TITLE
Fixed a security vulnerability for jackson databind 3.1.4->3.1.5

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -30,6 +30,17 @@
 		<java.version>17</java.version>
 		<sonar.organization>softeng-310-group-4</sonar.organization>
 	</properties>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>tools.jackson.core</groupId>
+				<artifactId>jackson-databind</artifactId>
+				<version>3.1.5</version>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
Fixed the first vulnerability detected by Snyk by changing the Jackson databind version in the server pom.xml folder to a newer version, contributes towards #45 