### PR TITLE
Prevent duplicate products from being selected in dropdown basket

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -226,11 +226,23 @@ function App() {
                     disabled={products.length === 0}
                   >
                     <option value="">Select a product</option>
-                    {products.map((product) => (
-                      <option key={product.productId} value={product.productId}>
-                        {product.displayName}
-                      </option>
-                    ))}
+                    {products.map((product) => {
+                      const isSelectedElsewhere = cartLines.some(
+                        (otherLine, otherIndex) =>
+                          otherIndex !== index && String(otherLine.productId) === String(product.productId)
+                      )
+
+                      return (
+                        <option
+                          key={product.productId}
+                          value={product.productId}
+                          disabled={isSelectedElsewhere}
+                        >
+                          {product.displayName}
+                          {isSelectedElsewhere ? ' (Already added)' : ''}
+                        </option>
+                      )
+                    })}
                   </select>
                 </label>
 


### PR DESCRIPTION
Worked to fix bug that allowed multiple entries of the same product to be selected in the dropdown menu. Instead, other products that have been selected will be greyed out and have "(Already added)" appended to them. 

Addresses #44  