### PR TITLE
empty basket rows removed upon changing filter or using comparison tool

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -70,17 +70,18 @@ function App() {
     setComparison(null)
 
     try {
+      const validLines = cartLines.filter((line) => line.productId !== '')
+
       const payload = {
-        items: cartLines
-          .filter((line) => line.productId !== '')
-          .map((line) => ({
-            productId: Number(line.productId),
-            quantity: Number(line.quantity),
-          })),
+        items: validLines.map((line) => ({
+          productId: Number(line.productId),
+          quantity: Number(line.quantity),
+        })),
       }
 
       const data = await compareBasket(payload)
 
+      setCartLines(validLines)
       setComparison(data)
     } catch (submitError) {
       setError(submitError.message)

--- a/client/src/tests/App.test.jsx
+++ b/client/src/tests/App.test.jsx
@@ -156,7 +156,7 @@ describe('basket interaction with the filter', () => {
     })
   })
 
-  it('clears a basket line whose product falls outside the filter', async () => {
+  it('removes a basket line whose product falls outside the filter', async () => {
     const user = await renderAndLoad()
 
     const select = screen.getByRole('combobox')
@@ -165,8 +165,9 @@ describe('basket interaction with the filter', () => {
 
     await user.click(screen.getByRole('checkbox', { name: 'Vegan' }))
 
-    // Trim Milk is not vegan, so the line must stop pointing at it.
-    await waitFor(() => expect(screen.getByRole('combobox')).toHaveValue(''))
+    // Trim Milk is not vegan, so the line must be removed entirely, 
+    // rather than being left behind as an empty "Select a product" row.
+    await waitFor(() => expect(screen.queryByRole('combobox')).not.toBeInTheDocument())
   })
 
   it('keeps a basket line whose product still matches the filter', async () => {

--- a/client/src/utils/basketSync.js
+++ b/client/src/utils/basketSync.js
@@ -4,9 +4,7 @@
  */
 export function syncBasketWithFilteredProducts(currentLines, visibleProducts) {
     const visibleIds = new Set(visibleProducts.map((product) => product.productId))
-    return currentLines.map((line) => 
-    line.productId === '' || visibleIds.has(Number(line.productId)) 
-        ? line
-        : { ...line, productId: '' },
+    return currentLines.filter(
+        (line) => line.productId === '' || visibleIds.has(Number(line.productId)),
     )
 }


### PR DESCRIPTION
Made it so that whenever there were unselected/empty basket rows and the user decided to either change dietary filters or compare their basket across stores, the empty basket rows would be removed from the basket.

In addition, a change in one of the tests in App.test.jsx was made to test the new behaviour. All test pass and application works as intended.

Closes #48 