### PR TITLE
Feature/persist basket state

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -27,12 +27,22 @@ function App() {
   // the search endpoint from #14 is the only source that can apply the tags.
   function handleProductsLoaded(data) {
     setError('')
-    setCartLines((currentLines) => syncBasketWithFilteredProducts(currentLines, data))
+    setCartLines((currentLines) => {
+      const syncBasketLines = syncBasketWithFilteredProducts(currentLines, data)
 
-    if (!hasPrefilledBasket.current && data.length > 0) {
+      if (
+        !hasPrefilledBasket.current &&
+        data.length > 0 &&
+        syncBasketLines.length === 1 &&
+        syncBasketLines[0].productId === ''
+      ) {
+        hasPrefilledBasket.current = true
+        return [{ productId: String(data[0].productId), quantity: 1 }]
+      }
+
       hasPrefilledBasket.current = true
-      setCartLines([{ productId: String(data[0].productId), quantity: 1 }])
-    }
+      return syncBasketLines
+    })
   }
 
   const { products, loading: catalogueLoading } = useProductCatalogue(

--- a/client/src/hooks/useCartLines.js
+++ b/client/src/hooks/useCartLines.js
@@ -13,7 +13,8 @@ export function useCartLines(initialLines = [{...EMPTY_CART_LINE }]) {
     const [cartLines, setCartLines] = useState(() => getSavedCartLines(initialLines))
 
     useEffect(() => {
-        localStorage.setItem(KEEP_BASKET_STATE_KEY, JSON.stringify(cartLines))
+        const safeLines = isValidCartLines(cartLines) ? cartLines : []
+        localStorage.setItem(KEEP_BASKET_STATE_KEY, JSON.stringify(safeLines))
     }, [cartLines])
 
     function getSavedCartLines(initialLines) {
@@ -24,7 +25,8 @@ export function useCartLines(initialLines = [{...EMPTY_CART_LINE }]) {
         }
 
         try {
-            return JSON.parse(savedLines)
+            const parsed = JSON.parse(savedLines)
+            return isValidCartLines(parsed) ? parsed : initialLines
         } catch {
             return initialLines
         }
@@ -47,4 +49,21 @@ export function useCartLines(initialLines = [{...EMPTY_CART_LINE }]) {
     }
 
     return { cartLines, setCartLines, updateLine, addLine, removeLine }
+}
+
+/**
+ * Validate that data read from or written to localStorage is actually a basket and not anything malicious.
+ * Addresses security flag picked up by Sonar.
+ */
+function isValidCartLines(parsedValue) {
+    return (
+        Array.isArray(parsedValue) &&
+        parsedValue.every(
+             (line) =>
+                line !== null &&
+                typeof line === 'object' &&
+                typeof line.productId === 'string' &&
+                (typeof line.quantity === 'number' || typeof line.quantity === 'string'),
+        )
+    )
 }

--- a/client/src/hooks/useCartLines.js
+++ b/client/src/hooks/useCartLines.js
@@ -26,7 +26,7 @@ export function useCartLines(initialLines = [{...EMPTY_CART_LINE }]) {
         try {
             return JSON.parse(savedLines)
         } catch {
-            return [{...EMPTY_CART_LINE}]
+            return initialLines
         }
     }
 

--- a/client/src/hooks/useCartLines.js
+++ b/client/src/hooks/useCartLines.js
@@ -1,36 +1,69 @@
 import { useEffect, useState } from 'react'
 
 export const EMPTY_CART_LINE = { productId: '', quantity: 1 }
+const KEEP_BASKET_STATE_KEY = 'grocerfy-basket'
+
+/**
+ * Filters out any malicious basket lines and rebuilds the remaining ones from
+ * scratch, since values taken from localStorage cannot be blindly trusted.
+ * 
+ * Used both when reading data from and writing data to, as these are the
+ * exchange points between localStorage.
+ */
+function sanitizeCartLines(lines, fallbackLines = [{ ...EMPTY_CART_LINE }]) {
+    if (!Array.isArray(lines)) {
+        return fallbackLines
+    }
+
+    return lines
+        .filter((line) => {
+            if (!line || typeof line !== 'object' || Array.isArray(line)) {
+                return false
+            }
+
+            const validProductId =
+                line.productId === '' ||
+                (typeof line.productId === 'string' &&
+                    /^\d+$/.test(line.productId) &&
+                    Number(line.productId) > 0) ||
+                (Number.isInteger(line.productId) && line.productId > 0)
+            const quantity = Number(line.quantity)
+
+            return validProductId && Number.isInteger(quantity) && quantity >= 1
+        })
+        .map((line) => ({
+            productId: line.productId === '' ? '' : String(line.productId),
+            quantity: Number(line.quantity),
+        }))
+}
+
+function getSavedCartLines(initialLines) {
+    const savedLines = localStorage.getItem(KEEP_BASKET_STATE_KEY)
+
+    if (!savedLines) {
+        return sanitizeCartLines(initialLines)
+    }
+
+    try {
+        return sanitizeCartLines(JSON.parse(savedLines), initialLines)
+    } catch {
+        return sanitizeCartLines(initialLines)
+    }
+}
 
 /**
  * Collection of hooks for managing the basket line items (product + quantity).
  * Contains operations for adding, removing, and updating basket lines.
  */
-export function useCartLines(initialLines = [{...EMPTY_CART_LINE }]) {
-    const KEEP_BASKET_STATE_KEY = 'grocerfy-basket'
+export function useCartLines(initialLines = [{ ...EMPTY_CART_LINE }]) {
     // Let users have persisting basket state across different sessions, as long
     // as they are on the same host
     const [cartLines, setCartLines] = useState(() => getSavedCartLines(initialLines))
 
     useEffect(() => {
-        const safeLines = isValidCartLines(cartLines) ? cartLines : []
+        const safeLines = sanitizeCartLines(cartLines)
         localStorage.setItem(KEEP_BASKET_STATE_KEY, JSON.stringify(safeLines))
     }, [cartLines])
-
-    function getSavedCartLines(initialLines) {
-        const savedLines = localStorage.getItem(KEEP_BASKET_STATE_KEY)
-
-        if (!savedLines) {
-            return initialLines
-        }
-
-        try {
-            const parsed = JSON.parse(savedLines)
-            return isValidCartLines(parsed) ? parsed : initialLines
-        } catch {
-            return initialLines
-        }
-    }
 
     function updateLine(index, field, value) {
         setCartLines((currentLines) =>
@@ -41,7 +74,7 @@ export function useCartLines(initialLines = [{...EMPTY_CART_LINE }]) {
     }
 
     function addLine() {
-        setCartLines((currentLines) => [...currentLines, {...EMPTY_CART_LINE}])
+        setCartLines((currentLines) => [...currentLines, { ...EMPTY_CART_LINE }])
     }
 
     function removeLine(index) {
@@ -49,21 +82,4 @@ export function useCartLines(initialLines = [{...EMPTY_CART_LINE }]) {
     }
 
     return { cartLines, setCartLines, updateLine, addLine, removeLine }
-}
-
-/**
- * Validate that data read from or written to localStorage is actually a basket and not anything malicious.
- * Addresses security flag picked up by Sonar.
- */
-function isValidCartLines(parsedValue) {
-    return (
-        Array.isArray(parsedValue) &&
-        parsedValue.every(
-             (line) =>
-                line !== null &&
-                typeof line === 'object' &&
-                typeof line.productId === 'string' &&
-                (typeof line.quantity === 'number' || typeof line.quantity === 'string'),
-        )
-    )
 }

--- a/client/src/hooks/useCartLines.js
+++ b/client/src/hooks/useCartLines.js
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 export const EMPTY_CART_LINE = { productId: '', quantity: 1 }
 
@@ -7,7 +7,28 @@ export const EMPTY_CART_LINE = { productId: '', quantity: 1 }
  * Contains operations for adding, removing, and updating basket lines.
  */
 export function useCartLines(initialLines = [{...EMPTY_CART_LINE }]) {
-    const [cartLines, setCartLines] = useState(initialLines)
+    const KEEP_BASKET_STATE_KEY = 'grocerfy-basket'
+    // Let users have persisting basket state across different sessions, as long
+    // as they are on the same host
+    const [cartLines, setCartLines] = useState(() => getSavedCartLines(initialLines))
+
+    useEffect(() => {
+        localStorage.setItem(KEEP_BASKET_STATE_KEY, JSON.stringify(cartLines))
+    }, [cartLines])
+
+    function getSavedCartLines(initialLines) {
+        const savedLines = localStorage.getItem(KEEP_BASKET_STATE_KEY)
+
+        if (!savedLines) {
+            return initialLines
+        }
+
+        try {
+            return JSON.parse(savedLines)
+        } catch {
+            return [{...EMPTY_CART_LINE}]
+        }
+    }
 
     function updateLine(index, field, value) {
         setCartLines((currentLines) =>

--- a/client/src/tests/App.test.jsx
+++ b/client/src/tests/App.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, within } from '@testing-library/react'
+import { cleanup, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -192,4 +192,27 @@ describe('basket interaction with the filter', () => {
     await waitFor(() => expect(requestedUrls).toContain('/api/product?dietary=vegan'))
     expect(screen.getByRole('combobox')).toHaveValue('3')
   })
+
+  it('restores the basket after the app is reopened', async () => {
+  const user = await renderAndLoad()
+
+  await user.selectOptions(screen.getByRole('combobox'), '3')
+
+  const quantityInput = screen.getByRole('spinbutton')
+  await user.clear(quantityInput)
+  await user.type(quantityInput, '2')
+
+  // Simulate closing the app.
+  cleanup()
+
+  // Simulate reopening the app.
+  render(<App />)
+
+  await waitFor(() => {
+    expect(within(catalogue()).getByText('Apple')).toBeInTheDocument()
+  })
+
+  expect(screen.getByRole('combobox')).toHaveValue('3')
+  expect(screen.getByRole('spinbutton')).toHaveValue(2)
+})
 })

--- a/client/src/tests/setup.js
+++ b/client/src/tests/setup.js
@@ -1,9 +1,13 @@
 import '@testing-library/jest-dom/vitest'
 import { cleanup } from '@testing-library/react'
-import { afterEach } from 'vitest'
+import { beforeEach, afterEach } from 'vitest'
 
 // React Testing Library does not unmount automatically between tests, so state
 // from one test would otherwise leak into the next.
+beforeEach(() => {
+  localStorage.clear()
+})
+
 afterEach(() => {
   cleanup()
 })

--- a/client/src/tests/useCartLines.test.jsx
+++ b/client/src/tests/useCartLines.test.jsx
@@ -96,4 +96,56 @@ describe('useCartLines', () => {
 
     expect(result.current.cartLines).toEqual([{ productId: '7', quantity: 4 }])
   })
+
+    it('saves basket changes to localStorage', () => {
+    const { result } = renderHook(() => useCartLines())
+
+    act(() => {
+      result.current.updateLine(0, 'productId', '3')
+    })
+
+    expect(JSON.parse(localStorage.getItem('grocerfy-basket'))).toEqual([
+      { productId: '3', quantity: 1 },
+    ])
+  })
+
+  it('restores the basket from localStorage', () => {
+    const savedLines = [
+      { productId: '3', quantity: 2 },
+      { productId: '5', quantity: 1 },
+    ]
+
+    localStorage.setItem('grocerfy-basket', JSON.stringify(savedLines))
+
+    const { result } = renderHook(() => useCartLines())
+
+    expect(result.current.cartLines).toEqual(savedLines)
+  })
+
+  it('restores the basket after the hook is recreated', () => {
+    const firstRender = renderHook(() => useCartLines())
+
+    act(() => {
+      firstRender.result.current.updateLine(0, 'productId', '4')
+      firstRender.result.current.updateLine(0, 'quantity', 3)
+    })
+
+    firstRender.unmount()
+
+    const secondRender = renderHook(() => useCartLines())
+
+    expect(secondRender.result.current.cartLines).toEqual([
+      { productId: '4', quantity: 3 },
+    ])
+  })
+
+  it('uses initial lines when saved basket data is malformed', () => {
+    const initialLines = [{ productId: '4', quantity: 2 }]
+
+    localStorage.setItem('grocerfy-basket', 'invalid json')
+
+    const { result } = renderHook(() => useCartLines(initialLines))
+
+    expect(result.current.cartLines).toEqual(initialLines)
+  })
 })

--- a/server/src/main/java/nz/ac/auckland/grocerfy/service/BasketComparisonService.java
+++ b/server/src/main/java/nz/ac/auckland/grocerfy/service/BasketComparisonService.java
@@ -7,7 +7,6 @@ import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;


### PR DESCRIPTION
Added functionality that lets user's basket selections from previous sessions persist using `localStorage`. As long as they are on the same host, all the contents they had will be kept when reopening the app again. Also considered preserving default initial basket for new users.

Added test coverage for new functionality. Tested things on my end and everything seemed to work fine.

Closes #74 